### PR TITLE
Fix hero image fade

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,6 +134,34 @@
       flex-wrap: wrap;
       gap: 0.5rem;
     }
+    .hero {
+      position: relative;
+      overflow: hidden;
+    }
+
+    .hero::after {
+      content: "";
+      position: absolute;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      height: 25%;
+      background: linear-gradient(to top, #000, transparent);
+      pointer-events: none;
+    }
+
+    .hero::before {
+      content: "";
+      position: absolute;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      height: 2px;
+      background: var(--gold);
+      box-shadow: 0 0 15px 5px rgba(212,175,55,0.5);
+      pointer-events: none;
+    }
+
     .hero-wrapper {
       display: flex;
       justify-content: center;


### PR DESCRIPTION
## Summary
- overlay a gradient fade and gold glow at the bottom of the hero section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684be1720fa48325832ee7d073a47d00