### PR TITLE
Delay reveal of never restocked text

### DIFF
--- a/index.html
+++ b/index.html
@@ -1008,7 +1008,9 @@
     }
 
     function startTextFlicker() {
-      scheduleFlickers(5000, 300, 800, neverText, 'text-flicker', true);
+      const duration = 5000;
+      scheduleFlickers(duration, 300, 800, neverText, 'text-flicker', true);
+      setTimeout(() => { neverText.style.opacity = '1'; }, duration + 250);
     }
 
     const productObserver = new IntersectionObserver((entries) => {

--- a/index.html
+++ b/index.html
@@ -807,6 +807,7 @@
       text-shadow: 0 0 6px rgba(191,167,94,0.4);
       margin-bottom: 1rem;
       text-align: center;
+      opacity: 0; /* hide until flicker starts */
     }
     /* Flicker helper classes */
     .bar-flicker { animation: flicker 0.15s steps(2); }
@@ -1002,7 +1003,7 @@
       setTimeout(() => {
         productSection.classList.add('disappear');
         cryptic.classList.add('show');
-        startTextFlicker();
+        setTimeout(startTextFlicker, 1000); // delay text appearance by 1s
       }, total + 250);
     }
 


### PR DESCRIPTION
## Summary
- keep "Never Restocked" hidden until the flicker begins
- delay start of text flicker by 1s when the bar completes

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685cd9fab6608325826370ed41a235fa