### PR TITLE
Adjust Never Restocked flicker timing

### DIFF
--- a/index.html
+++ b/index.html
@@ -812,8 +812,8 @@
     /* Flicker helper classes */
     .bar-flicker { animation: flicker 0.15s steps(2); }
     .bar-flicker-strong { animation: flicker-strong 0.25s steps(2); }
-    .text-flicker { animation: flicker 0.15s steps(2); }
-    .text-flicker-strong { animation: flicker-strong 0.25s steps(2); }
+    .text-flicker { animation: flicker 0.3s steps(2); }
+    .text-flicker-strong { animation: flicker-strong 0.45s steps(2); }
     .cryptic-logo {
       width: 60%;
       max-width: 180px;
@@ -992,7 +992,7 @@
         const cls = strong ? baseCls + '-strong' : baseCls;
         setTimeout(() => {
           element.classList.add(cls);
-          setTimeout(() => element.classList.remove(cls), strong ? 250 : 150);
+          setTimeout(() => element.classList.remove(cls), strong ? 450 : 300);
         }, t);
       });
     }


### PR DESCRIPTION
## Summary
- slow down flicker animation for the `Never Restocked` text

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685cde8b8c408325a861f5b64f215300