### PR TITLE
Add interactive zoom for product origin images

### DIFF
--- a/bloomveil.html
+++ b/bloomveil.html
@@ -282,13 +282,14 @@
       pointer-events: none;
     }
 
-    .origin-media img {
+    .origin-media .zoomable {
       width: min(60vw, 520px);
-      height: auto;
-      object-fit: cover;
       border-radius: 16px;
-      display: block;
       box-shadow: 0 25px 55px rgba(0, 0, 0, 0.65);
+    }
+
+    .origin-media .zoomable img {
+      border-radius: inherit;
     }
 
     #product-craft {
@@ -481,7 +482,7 @@
         inset: 8px;
       }
 
-      .origin-media img {
+      .origin-media .zoomable {
         width: 100%;
         max-width: 420px;
       }
@@ -602,7 +603,9 @@
           <p data-animate>A study in restraint — beauty held in control. Bloomveil celebrates serenity under pressure and the discipline to remain calm.</p>
         </div>
         <div class="origin-media" data-animate>
-          <img src="/images/Bloomveil.png" alt="Bloomveil detail view" loading="lazy" decoding="async">
+          <div class="zoomable">
+            <img src="/images/Bloomveil.png" alt="Bloomveil detail view" loading="lazy" decoding="async">
+          </div>
         </div>
       </div>
     </section>
@@ -753,6 +756,7 @@
     </footer>
   </aside>
 
+  <script src="/js/zoom.js" defer></script>
   <script src="/js/cart.js" defer></script>
 </body>
 </html>

--- a/feral-doctrine.html
+++ b/feral-doctrine.html
@@ -282,13 +282,14 @@
       pointer-events: none;
     }
 
-    .origin-media img {
+    .origin-media .zoomable {
       width: min(60vw, 520px);
-      height: auto;
-      object-fit: cover;
       border-radius: 16px;
-      display: block;
       box-shadow: 0 25px 55px rgba(0, 0, 0, 0.65);
+    }
+
+    .origin-media .zoomable img {
+      border-radius: inherit;
     }
 
     #product-craft {
@@ -481,7 +482,7 @@
         inset: 8px;
       }
 
-      .origin-media img {
+      .origin-media .zoomable {
         width: 100%;
         max-width: 420px;
       }
@@ -602,7 +603,9 @@
           <p data-animate>Raw energy meets discipline. Scribbled defiance, contained by structure. Feral Doctrine is our oath to courage in the chaos.</p>
         </div>
         <div class="origin-media" data-animate>
-          <img src="/images/Feral%20Doctrine.png" alt="Feral Doctrine detail view" loading="lazy" decoding="async">
+          <div class="zoomable">
+            <img src="/images/Feral%20Doctrine.png" alt="Feral Doctrine detail view" loading="lazy" decoding="async">
+          </div>
         </div>
       </div>
     </section>
@@ -753,6 +756,7 @@
     </footer>
   </aside>
 
+  <script src="/js/zoom.js" defer></script>
   <script src="/js/cart.js" defer></script>
 </body>
 </html>

--- a/hero.css
+++ b/hero.css
@@ -25,6 +25,11 @@ body{margin:0;background:var(--bg);color:var(--text);font-family:ui-sans-serif,s
 .journal-card__link{margin-top:6px;color:#d7c07a;text-decoration:none;font-weight:600;letter-spacing:.04em;display:inline-flex;align-items:center;gap:6px;min-height:44px}
 .journal-card__link:hover{text-decoration:underline}
 
+.zoomable{position:relative;display:block;overflow:hidden;border-radius:16px;cursor:zoom-in;touch-action:none}
+.zoomable img{display:block;width:100%;height:auto;transition:transform .35s ease;transform-origin:center center;will-change:transform}
+.zoomable.is-zoomed{cursor:zoom-out}
+.zoomable.is-zoomed img{transition:transform .08s ease-out}
+
 .site-header{
  position:sticky;top:0;z-index:50;display:flex;align-items:center;justify-content:space-between;
  padding:12px 24px;background:rgba(0,0,0,.7);backdrop-filter:saturate(110%) blur(6px);

--- a/hero.css
+++ b/hero.css
@@ -26,7 +26,7 @@ body{margin:0;background:var(--bg);color:var(--text);font-family:ui-sans-serif,s
 .journal-card__link:hover{text-decoration:underline}
 
 .zoomable{position:relative;display:block;overflow:hidden;border-radius:16px;cursor:zoom-in;touch-action:none}
-.zoomable img{display:block;width:100%;height:auto;transition:transform .35s ease;transform-origin:center center;will-change:transform}
+.zoomable img{display:block;width:100%;height:auto;transition:transform .35s ease;transform-origin:top left;will-change:transform}
 .zoomable.is-zoomed{cursor:zoom-out}
 .zoomable.is-zoomed img{transition:transform .08s ease-out}
 

--- a/js/zoom.js
+++ b/js/zoom.js
@@ -1,0 +1,85 @@
+(function () {
+  const DEFAULT_SCALE = 2;
+
+  function clamp(value, min, max) {
+    return Math.min(Math.max(value, min), max);
+  }
+
+  function updateTransform(wrapper, image, event, scale) {
+    const rect = wrapper.getBoundingClientRect();
+    const pointX = clamp((event.clientX - rect.left) / rect.width, 0, 1);
+    const pointY = clamp((event.clientY - rect.top) / rect.height, 0, 1);
+    const translateX = pointX * (scale - 1) * 100;
+    const translateY = pointY * (scale - 1) * 100;
+
+    image.style.transform = `translate(-${translateX}%, -${translateY}%) scale(${scale})`;
+  }
+
+  function normalizeEvent(event) {
+    if (event.touches && event.touches[0]) {
+      return event.touches[0];
+    }
+
+    if (event.changedTouches && event.changedTouches[0]) {
+      return event.changedTouches[0];
+    }
+
+    return event;
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const zoomables = document.querySelectorAll('.zoomable');
+
+    zoomables.forEach((wrapper) => {
+      const image = wrapper.querySelector('img');
+      if (!image) {
+        return;
+      }
+
+      const scale = parseFloat(wrapper.getAttribute('data-zoom-scale')) || DEFAULT_SCALE;
+      let zoomed = false;
+
+      const handleMove = (event) => {
+        if (!zoomed) {
+          return;
+        }
+
+        const point = normalizeEvent(event);
+        updateTransform(wrapper, image, point, scale);
+      };
+
+      wrapper.addEventListener('click', (event) => {
+        zoomed = !zoomed;
+        wrapper.classList.toggle('is-zoomed', zoomed);
+
+        if (zoomed) {
+          const point = normalizeEvent(event);
+          updateTransform(wrapper, image, point, scale);
+        } else {
+          image.style.transform = '';
+        }
+      });
+
+      wrapper.addEventListener('pointermove', handleMove);
+      wrapper.addEventListener('mousemove', handleMove);
+      wrapper.addEventListener('touchmove', (event) => {
+        handleMove(event);
+        if (zoomed) {
+          event.preventDefault();
+        }
+      }, { passive: false });
+
+      wrapper.addEventListener('pointerleave', () => {
+        if (!zoomed) {
+          image.style.transform = '';
+        }
+      });
+
+      wrapper.addEventListener('touchend', (event) => {
+        if (!zoomed) {
+          image.style.transform = '';
+        }
+      });
+    });
+  });
+})();

--- a/oathbound.html
+++ b/oathbound.html
@@ -282,13 +282,14 @@
       pointer-events: none;
     }
 
-    .origin-media img {
+    .origin-media .zoomable {
       width: min(60vw, 520px);
-      height: auto;
-      object-fit: cover;
       border-radius: 16px;
-      display: block;
       box-shadow: 0 25px 55px rgba(0, 0, 0, 0.65);
+    }
+
+    .origin-media .zoomable img {
+      border-radius: inherit;
     }
 
     #product-craft {
@@ -481,7 +482,7 @@
         inset: 8px;
       }
 
-      .origin-media img {
+      .origin-media .zoomable {
         width: 100%;
         max-width: 420px;
       }
@@ -602,7 +603,9 @@
           <p data-animate>Inscribed by time. Oathbound carries fragments of vows and memory — a relic built for those devoted to the craft.</p>
         </div>
         <div class="origin-media" data-animate>
-          <img src="/images/Oathbound.png" alt="Oathbound detail view" loading="lazy" decoding="async">
+          <div class="zoomable">
+            <img src="/images/Oathbound.png" alt="Oathbound detail view" loading="lazy" decoding="async">
+          </div>
         </div>
       </div>
     </section>
@@ -753,6 +756,7 @@
     </footer>
   </aside>
 
+  <script src="/js/zoom.js" defer></script>
   <script src="/js/cart.js" defer></script>
 </body>
 </html>

--- a/valyr.html
+++ b/valyr.html
@@ -282,13 +282,14 @@
       pointer-events: none;
     }
 
-    .origin-media img {
+    .origin-media .zoomable {
       width: min(60vw, 520px);
-      height: auto;
-      object-fit: cover;
       border-radius: 16px;
-      display: block;
       box-shadow: 0 25px 55px rgba(0, 0, 0, 0.65);
+    }
+
+    .origin-media .zoomable img {
+      border-radius: inherit;
     }
 
     #product-craft {
@@ -481,7 +482,7 @@
         inset: 8px;
       }
 
-      .origin-media img {
+      .origin-media .zoomable {
         width: 100%;
         max-width: 420px;
       }
@@ -602,7 +603,9 @@
           <p data-animate>Valyr channels grace under pressure — inspired by motion drawn in ink. A statement of restraint and expression forged for those who strike with precision.</p>
         </div>
         <div class="origin-media" data-animate>
-          <img src="/images/Valyr.png" alt="Valyr detail view" loading="lazy" decoding="async">
+          <div class="zoomable">
+            <img src="/images/Valyr.png" alt="Valyr detail view" loading="lazy" decoding="async">
+          </div>
         </div>
       </div>
     </section>
@@ -753,6 +756,7 @@
     </footer>
   </aside>
 
+  <script src="/js/zoom.js" defer></script>
   <script src="/js/cart.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add reusable `.zoomable` styles and shared zoom.js script for interactive product imagery
- wrap the Origin-section images on the Valyr, Feral Doctrine, Bloomveil, and Oathbound pages with the new zoom container
- hook up the zoom behavior script across the affected pages for smooth click-to-zoom and cursor feedback

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690b1b8d36348325a3ef27784c5c3a60