### PR TITLE
Remove duplicate hero meta sections from product pages

### DIFF
--- a/bloomveil.html
+++ b/bloomveil.html
@@ -125,27 +125,6 @@
       justify-content: center;
     }
 
-    #meta-block {
-      background: #080808;
-      padding: 28px 0 36px;
-      position: relative;
-      box-shadow: 0 -20px 40px rgba(0, 0, 0, 0.55);
-      z-index: 3;
-    }
-
-    #meta-block .p-wrap {
-      text-align: center;
-    }
-
-    #meta-block .meta-title {
-      font-family: 'Cinzel', serif;
-      font-size: clamp(1.8rem, 4vw, 2.4rem);
-      letter-spacing: 0.12em;
-      text-transform: uppercase;
-      margin: 0 0 0.5rem;
-      color: #f3f3f3;
-    }
-
     .sub {
       color: var(--gold);
       letter-spacing: 0.18em;
@@ -487,9 +466,6 @@
         max-width: 420px;
       }
 
-      #meta-block .btn-row {
-        justify-content: center;
-      }
     }
 
     @media (max-width: 640px) {
@@ -567,19 +543,6 @@
       <div class="overlay" aria-hidden="true"></div>
       <div class="meta">
         <h1 data-animate>GARMR: Bloomveil</h1>
-        <p class="sub" data-animate>Soft power. Eternal bloom.</p>
-        <p class="price" data-animate>$199</p>
-        <div class="btn-row" data-animate>
-          <a class="btn-gold" href="/cart.html">Cart</a>
-          <a href="/collection.html" class="btn-outline">Explore Collection</a>
-          <a href="/contact.html" class="btn-link">Contact support</a>
-        </div>
-      </div>
-    </section>
-
-    <section id="meta-block">
-      <div class="p-wrap">
-        <p class="meta-title" data-animate role="heading" aria-level="1">GARMR: Bloomveil</p>
         <p class="sub" data-animate>Soft power. Eternal bloom.</p>
         <p class="price" data-animate>$199</p>
         <div class="btn-row" data-animate>

--- a/feral-doctrine.html
+++ b/feral-doctrine.html
@@ -125,27 +125,6 @@
       justify-content: center;
     }
 
-    #meta-block {
-      background: #080808;
-      padding: 28px 0 36px;
-      position: relative;
-      box-shadow: 0 -20px 40px rgba(0, 0, 0, 0.55);
-      z-index: 3;
-    }
-
-    #meta-block .p-wrap {
-      text-align: center;
-    }
-
-    #meta-block .meta-title {
-      font-family: 'Cinzel', serif;
-      font-size: clamp(1.8rem, 4vw, 2.4rem);
-      letter-spacing: 0.12em;
-      text-transform: uppercase;
-      margin: 0 0 0.5rem;
-      color: #f3f3f3;
-    }
-
     .sub {
       color: var(--gold);
       letter-spacing: 0.18em;
@@ -487,9 +466,6 @@
         max-width: 420px;
       }
 
-      #meta-block .btn-row {
-        justify-content: center;
-      }
     }
 
     @media (max-width: 640px) {
@@ -567,19 +543,6 @@
       <div class="overlay" aria-hidden="true"></div>
       <div class="meta">
         <h1 data-animate>GARMR: Feral Doctrine</h1>
-        <p class="sub" data-animate>No gods. No chains.</p>
-        <p class="price" data-animate>$219</p>
-        <div class="btn-row" data-animate>
-          <a class="btn-gold" href="/cart.html">Cart</a>
-          <a href="/collection.html" class="btn-outline">Explore Collection</a>
-          <a href="/contact.html" class="btn-link">Contact support</a>
-        </div>
-      </div>
-    </section>
-
-    <section id="meta-block">
-      <div class="p-wrap">
-        <p class="meta-title" data-animate role="heading" aria-level="1">GARMR: Feral Doctrine</p>
         <p class="sub" data-animate>No gods. No chains.</p>
         <p class="price" data-animate>$219</p>
         <div class="btn-row" data-animate>

--- a/oathbound.html
+++ b/oathbound.html
@@ -125,27 +125,6 @@
       justify-content: center;
     }
 
-    #meta-block {
-      background: #080808;
-      padding: 28px 0 36px;
-      position: relative;
-      box-shadow: 0 -20px 40px rgba(0, 0, 0, 0.55);
-      z-index: 3;
-    }
-
-    #meta-block .p-wrap {
-      text-align: center;
-    }
-
-    #meta-block .meta-title {
-      font-family: 'Cinzel', serif;
-      font-size: clamp(1.8rem, 4vw, 2.4rem);
-      letter-spacing: 0.12em;
-      text-transform: uppercase;
-      margin: 0 0 0.5rem;
-      color: #f3f3f3;
-    }
-
     .sub {
       color: var(--gold);
       letter-spacing: 0.18em;
@@ -487,9 +466,6 @@
         max-width: 420px;
       }
 
-      #meta-block .btn-row {
-        justify-content: center;
-      }
     }
 
     @media (max-width: 640px) {
@@ -567,19 +543,6 @@
       <div class="overlay" aria-hidden="true"></div>
       <div class="meta">
         <h1 data-animate>GARMR: Oathbound</h1>
-        <p class="sub" data-animate>Every strike leaves a story.</p>
-        <p class="price" data-animate>$229</p>
-        <div class="btn-row" data-animate>
-          <a class="btn-gold" href="/cart.html">Cart</a>
-          <a href="/collection.html" class="btn-outline">Explore Collection</a>
-          <a href="/contact.html" class="btn-link">Contact support</a>
-        </div>
-      </div>
-    </section>
-
-    <section id="meta-block">
-      <div class="p-wrap">
-        <p class="meta-title" data-animate role="heading" aria-level="1">GARMR: Oathbound</p>
         <p class="sub" data-animate>Every strike leaves a story.</p>
         <p class="price" data-animate>$229</p>
         <div class="btn-row" data-animate>

--- a/valyr.html
+++ b/valyr.html
@@ -125,27 +125,6 @@
       justify-content: center;
     }
 
-    #meta-block {
-      background: #080808;
-      padding: 28px 0 36px;
-      position: relative;
-      box-shadow: 0 -20px 40px rgba(0, 0, 0, 0.55);
-      z-index: 3;
-    }
-
-    #meta-block .p-wrap {
-      text-align: center;
-    }
-
-    #meta-block .meta-title {
-      font-family: 'Cinzel', serif;
-      font-size: clamp(1.8rem, 4vw, 2.4rem);
-      letter-spacing: 0.12em;
-      text-transform: uppercase;
-      margin: 0 0 0.5rem;
-      color: #f3f3f3;
-    }
-
     .sub {
       color: var(--gold);
       letter-spacing: 0.18em;
@@ -487,9 +466,6 @@
         max-width: 420px;
       }
 
-      #meta-block .btn-row {
-        justify-content: center;
-      }
     }
 
     @media (max-width: 640px) {
@@ -567,19 +543,6 @@
       <div class="overlay" aria-hidden="true"></div>
       <div class="meta">
         <h1 data-animate>GARMR: Valyr</h1>
-        <p class="sub" data-animate>The elegance of control.</p>
-        <p class="price" data-animate>$189</p>
-      <div class="btn-row" data-animate>
-        <a class="btn-gold" href="/cart.html">Cart</a>
-        <a href="/collection.html" class="btn-outline">Explore Collection</a>
-        <a href="/contact.html" class="btn-link">Contact support</a>
-      </div>
-      </div>
-    </section>
-
-    <section id="meta-block">
-      <div class="p-wrap">
-        <p class="meta-title" data-animate role="heading" aria-level="1">GARMR: Valyr</p>
         <p class="sub" data-animate>The elegance of control.</p>
         <p class="price" data-animate>$189</p>
         <div class="btn-row" data-animate>


### PR DESCRIPTION
## Summary
- remove the redundant meta-block sections from the Valyr, Feral Doctrine, Bloomveil, and Oathbound pages
- move the add-to-cart CTA into each hero banner and drop the unused styles tied to the deleted block

## Testing
- not run (static changes)


------
https://chatgpt.com/codex/tasks/task_e_690b1fb94c988325a26ef7d3f58b5a35